### PR TITLE
Handle ||

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,37 +25,37 @@ fn main() {
         println!("No previous history.");
         File::create(format!("{}/.rush_history", home)).expect("Couldn't create history file");
     }
-    loop {
-        let prompt_string = generate_prompt(last_exit_status);
-        let command_string = read_command(&mut rl, prompt_string);
-        let commands = tokenize_commands(&command_string);
+    // loop {
+    //     let prompt_string = generate_prompt(last_exit_status);
+    //     let command_string = read_command(&mut rl, prompt_string);
+    //     let commands = tokenize_commands(&command_string);
 
-        for mut command in commands {
-            last_exit_status = true;
-            for mut dependent_command in command {
-                let mut is_background = false;
-                if let Some(&"&") = dependent_command.last() {
-                    is_background = true;
-                    dependent_command.pop();
-                }
-                match dependent_command[0] {
-                    "exit" => {
-                        rl.save_history(&format!("{}/.rush_history", home)).expect("Couldn't save history");
-                        std::process::exit(0);
-                    },
-                    "cd" => {
-                        last_exit_status = change_dir(dependent_command[1]);
-                    }
-                    _ => {
-                        last_exit_status = execute_command(dependent_command, is_background);
-                    }
-                }
-                if last_exit_status == false {
-                    break;
-                }
-            }
-        }
-    }
+    //     for mut command in commands {
+    //         last_exit_status = true;
+    //         for mut dependent_command in command {
+    //             let mut is_background = false;
+    //             if let Some(&"&") = dependent_command.last() {
+    //                 is_background = true;
+    //                 dependent_command.pop();
+    //             }
+    //             match dependent_command[0] {
+    //                 "exit" => {
+    //                     rl.save_history(&format!("{}/.rush_history", home)).expect("Couldn't save history");
+    //                     std::process::exit(0);
+    //                 },
+    //                 "cd" => {
+    //                     last_exit_status = change_dir(dependent_command[1]);
+    //                 }
+    //                 _ => {
+    //                     last_exit_status = execute_command(dependent_command, is_background);
+    //                 }
+    //             }
+    //             if last_exit_status == false {
+    //                 break;
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 fn read_command(rl: &mut Editor<()>, prompt_string: String) -> String {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -33,15 +33,24 @@ impl Tokens {
 pub fn tokenize_commands(command_string : &str) -> Vec<Tokens> {
     let mut commands: Vec<Tokens> = vec![];
     for independent_com in command_string.split(';') {
-        let mut processes : Vec<&str> = independent_com.split(" & ").collect();
-        let foreground = processes.pop();
+        let mut processes : Vec<&str> = independent_com.trim().split(" & ").collect();
+        let foreground = processes.pop(); 
         for background_process in processes {
             if background_process != "" {
                 commands.push(Tokens::new(background_process, true));
             }
         }
         match foreground {
-            Some(str) => if str != "" {commands.push(Tokens::new(str, false))},
+            Some(str) => 
+            if str.ends_with('&') { 
+                let mut chars = str.chars();
+                chars.next_back();
+                let str_b = chars.as_str();
+                commands.push(Tokens::new(str_b, true))
+            }
+            else if str != "" {commands.push(Tokens::new(str, false))}
+            else {}
+            ,
             None => ()
         }
         

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -32,26 +32,28 @@ impl Tokens {
 pub fn tokenize_commands(command_string : &str) -> Vec<Tokens> {
     let mut commands: Vec<Tokens> = vec![];
     for independent_com in command_string.split(';') {
-        let mut processes : Vec<&str> = independent_com.trim().split(" & ").collect();
-        let foreground = processes.pop(); 
-        for background_process in processes {
-            if background_process != "" {
-                commands.push(Tokens::new(background_process, true));
+        for dependent_coms in independent_com.split("&&"){
+            let mut processes : Vec<&str> = dependent_coms.trim().split(" & ").collect();
+            let foreground = processes.pop(); 
+            for background_process in processes {
+                if background_process != "" {
+                    commands.push(Tokens::new(background_process, true));
+                }
             }
-        }
-        match foreground {
-            Some(str) => 
-            if str.ends_with('&') { 
-                let mut chars = str.chars();
-                chars.next_back();
-                let str_b = chars.as_str();
-                commands.push(Tokens::new(str_b, true))
+            match foreground {
+                Some(str) => 
+                if str.ends_with('&') { 
+                    let mut chars = str.chars();
+                    chars.next_back();
+                    let str_b = chars.as_str();
+                    commands.push(Tokens::new(str_b, true))
+                }
+                else if str != "" {commands.push(Tokens::new(str, false))}
+                else {}
+                ,
+                None => ()
             }
-            else if str != "" {commands.push(Tokens::new(str, false))}
-            else {}
-            ,
-            None => ()
-        }
+            }
         
     }
     commands
@@ -123,7 +125,7 @@ mod tests {
         let tokens = tokenize_commands(commands);
 
         assert_eq!(vec![
-            Tokens {main_com : String::from("date"), args: vec![String::from("&&"), String::from("ls")], in_background : false}, 
+            Tokens {main_com : String::from("date"), args: vec![], in_background:false}, Tokens{main_com : String::from("ls"), args: vec![], in_background : false} 
             ], tokens);
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -7,9 +7,9 @@ args are every term that follows separated by a whitespace after the main comman
 
 #[derive(Debug, PartialEq)]
 pub struct Tokens {
-    main_com : String,
-    args : Vec<String>,
-    in_background : bool
+    pub main_com : String,
+    pub args : Vec<String>,
+    pub in_background : bool
 }
 
 impl Tokens {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -5,7 +5,6 @@ Independent commands that finish with '&' run in the background
 args are every term that follows separated by a whitespace after the main command
 */
 
-
 #[derive(Debug, PartialEq)]
 pub struct Tokens {
     main_com : String,


### PR DESCRIPTION
I have completely removed the previous vec<vec<vec<str>>>> structure and gone for a struct for Tokens. 
Here tokens will have fields, main_com (main command), args, or_com (to handle || logical operator), and in_background boolean to identify if command runs in the background or not.

I have fixed the following issue:
1) Handling & for background processes. Even though '&' at end of command is handled, '&' within the command was not handled accurately. 
Enabled features
1) || logical operator implementation

The logical operator doesn't work with cd command, as the change_directory function is outside of the execute command. 
In the future it would be better to call and handle cd from within the execute command. 