### PR TITLE
History hinter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +45,17 @@ checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
 dependencies = [
  "error-code",
  "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
  "winapi",
 ]
 
@@ -118,10 +140,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -227,6 +264,7 @@ dependencies = [
 name = "rush"
 version = "0.1.0"
 dependencies = [
+ "colored",
  "libc",
  "rustyline",
  "rustyline-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,17 +34,6 @@ checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
 dependencies = [
  "error-code",
  "str-buf",
- "winapi",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
  "winapi",
 ]
 
@@ -140,25 +118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -264,7 +227,6 @@ dependencies = [
 name = "rush"
 version = "0.1.0"
 dependencies = [
- "colored",
  "libc",
  "rustyline",
  "rustyline-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "rustyline",
+ "rustyline-derive",
 ]
 
 [[package]]
@@ -266,6 +267,17 @@ dependencies = [
  "unicode-width",
  "utf8parse",
  "winapi",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107c3d5d7f370ac09efa62a78375f94d94b8a33c61d8c278b96683fb4dbf2d8d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["psinghal20 <psinghal20@gmail.com>"]
 [dependencies]
 libc = "0.2"
 rustyline = "10.0.0"
+rustyline-derive = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["psinghal20 <psinghal20@gmail.com>"]
 libc = "0.2"
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
+colored = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,3 @@ authors = ["psinghal20 <psinghal20@gmail.com>"]
 libc = "0.2"
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
-colored = "2.0"

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -8,8 +8,8 @@ use rustyline::hint::HistoryHinter;
 #[derive(Helper, Validator, Hinter)]
 pub struct MyHelper {
     pub highlighter: MatchingBracketHighlighter,
-    // #[rustyline(Hinter)]
-    // pub hinter: HistoryHinter,
+    #[rustyline(Hinter)]
+    pub hinter: HistoryHinter,
 }
 impl Highlighter for MyHelper {
 
@@ -63,7 +63,7 @@ impl MyHelper {
     pub fn new() -> MyHelper {
         MyHelper{
             highlighter : MatchingBracketHighlighter::new(),
-            // hinter : HistoryHinter {}
+            hinter : HistoryHinter {}
         }
     }
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,19 +1,18 @@
-use colored::Colorize;
-use rustyline::completion::{Completer, Pair, Candidate};
+use rustyline::completion::{Completer, Pair};
 use rustyline_derive::{Helper, Validator, Hinter};
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
-use rustyline::{Context, ConditionalEventHandler, KeyEvent, EventContext, RepeatCount, Event, Cmd};
-use std::borrow::Cow::{self, Borrowed, Owned};
+use rustyline::{Context};
+use std::borrow::Cow::{self, Owned};
 use rustyline::hint::HistoryHinter;
 
 #[derive(Helper, Validator, Hinter)]
 pub struct MyHelper {
     pub highlighter: MatchingBracketHighlighter,
-    #[rustyline(Hinter)]
-    pub hinter: HistoryHinter,
+    // #[rustyline(Hinter)]
+    // pub hinter: HistoryHinter,
 }
 impl Highlighter for MyHelper {
-    
+
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
     }
@@ -45,8 +44,8 @@ impl Completer for MyHelper {
                         // FIXME move this to highlight_candidate when that accepts a completion::Candidate
                         display: format!(
                             "{}{}",
-                            &candidate[..pos].green(),
-                            &candidate[pos..].bright_green().bold()
+                            &candidate[..pos],
+                            &candidate[pos..]
                         ),
                         replacement: if candidates.len() == 1 {
                             format!("{} ", &candidate[pos..])
@@ -59,28 +58,12 @@ impl Completer for MyHelper {
             
     }
 }
-pub struct TabEventHandler;
-impl ConditionalEventHandler for TabEventHandler {
-    fn handle(&self, evt: &Event, n: RepeatCount, _: bool, ctx: &EventContext) -> Option<Cmd> {
-        debug_assert_eq!(*evt, Event::from(KeyEvent::from('\t')));
-        if ctx.line()[..ctx.pos()]
-            .chars()
-            .rev()
-            .next()
-            .filter(|c| c.is_whitespace())
-            .is_some()
-        {
-            Some(Cmd::SelfInsert(n, '\t'))
-        } else {
-            None // default complete
-        }
-    }
-}
+
 impl MyHelper {
     pub fn new() -> MyHelper {
         MyHelper{
             highlighter : MatchingBracketHighlighter::new(),
-            hinter : HistoryHinter {}
+            // hinter : HistoryHinter {}
         }
     }
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,79 @@
+use rustyline_derive::{Helper, Validator, Completer};
+use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline::hint::Hinter;
+use rustyline::history::SearchDirection;
+use rustyline::{Context, ConditionalEventHandler, KeyEvent, EventContext, RepeatCount, Event, Cmd};
+use std::borrow::Cow::{self, Borrowed, Owned};
+use rustyline::hint::HistoryHinter;
+
+#[derive(Helper, Validator, Completer)]
+pub struct MyHelper {
+    pub highlighter: MatchingBracketHighlighter,
+    #[rustyline(Hinter)]
+    pub hinter: HistoryHinter,
+}
+impl Highlighter for MyHelper {
+    
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
+    }
+
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
+        self.highlighter.highlight(line, pos)
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        self.highlighter.highlight_char(line, pos)
+    }
+}
+impl Hinter for MyHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        if line.is_empty() || pos < line.len() {
+            return None;
+        }
+        let start = if _ctx.history_index() == _ctx.history().len() {
+            _ctx.history_index().saturating_sub(1)
+        } else {
+            _ctx.history_index()
+        };
+        if let Some(sr) = _ctx
+            .history()
+            .starts_with(line, start, SearchDirection::Reverse)
+        {
+            if sr.entry == line {
+                return None;
+            }
+            return Some(sr.entry[pos..].to_owned());
+        }
+        None
+    }
+}
+
+pub struct TabEventHandler;
+impl ConditionalEventHandler for TabEventHandler {
+    fn handle(&self, evt: &Event, n: RepeatCount, _: bool, ctx: &EventContext) -> Option<Cmd> {
+        debug_assert_eq!(*evt, Event::from(KeyEvent::from('\t')));
+
+        if ctx.line()[..ctx.pos()]
+            .chars()
+            .rev()
+            .next()
+            .filter(|c| c.is_whitespace())
+            .is_some()
+        {
+            Some(Cmd::SelfInsert(n, '\t'))
+        } else {
+            None // default complete
+        }
+    }
+}
+impl MyHelper {
+    pub fn new() -> MyHelper {
+        MyHelper{
+            highlighter : MatchingBracketHighlighter::new(),
+            hinter : HistoryHinter {}
+        }
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,12 +1,12 @@
-use rustyline_derive::{Helper, Validator, Completer};
+use colored::Colorize;
+use rustyline::completion::{Completer, Pair, Candidate};
+use rustyline_derive::{Helper, Validator, Hinter};
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
-use rustyline::hint::Hinter;
-use rustyline::history::SearchDirection;
 use rustyline::{Context, ConditionalEventHandler, KeyEvent, EventContext, RepeatCount, Event, Cmd};
 use std::borrow::Cow::{self, Borrowed, Owned};
 use rustyline::hint::HistoryHinter;
 
-#[derive(Helper, Validator, Completer)]
+#[derive(Helper, Validator, Hinter)]
 pub struct MyHelper {
     pub highlighter: MatchingBracketHighlighter,
     #[rustyline(Hinter)]
@@ -26,36 +26,43 @@ impl Highlighter for MyHelper {
         self.highlighter.highlight_char(line, pos)
     }
 }
-impl Hinter for MyHelper {
-    type Hint = String;
 
-    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
-        if line.is_empty() || pos < line.len() {
-            return None;
-        }
-        let start = if _ctx.history_index() == _ctx.history().len() {
-            _ctx.history_index().saturating_sub(1)
-        } else {
-            _ctx.history_index()
-        };
-        if let Some(sr) = _ctx
+impl Completer for MyHelper {
+    type Candidate = Pair;
+
+    fn complete(&self, line: &str, pos: usize,ctx: &Context<'_> ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        let candidates : Vec<&String> = ctx
             .history()
-            .starts_with(line, start, SearchDirection::Reverse)
-        {
-            if sr.entry == line {
-                return None;
-            }
-            return Some(sr.entry[pos..].to_owned());
-        }
-        None
+            .iter()
+            .filter(|str| str.starts_with(line) && str.as_str() != line)
+            .collect();
+
+            Ok((
+                pos,
+                candidates
+                    .iter()
+                    .map(|&candidate| Pair {
+                        // FIXME move this to highlight_candidate when that accepts a completion::Candidate
+                        display: format!(
+                            "{}{}",
+                            &candidate[..pos].green(),
+                            &candidate[pos..].bright_green().bold()
+                        ),
+                        replacement: if candidates.len() == 1 {
+                            format!("{} ", &candidate[pos..])
+                        } else {
+                            candidate[pos..].to_owned()
+                        },
+                    })
+                    .collect(),
+            ))        
+            
     }
 }
-
 pub struct TabEventHandler;
 impl ConditionalEventHandler for TabEventHandler {
     fn handle(&self, evt: &Event, n: RepeatCount, _: bool, ctx: &EventContext) -> Option<Cmd> {
         debug_assert_eq!(*evt, Event::from(KeyEvent::from('\t')));
-
         if ctx.line()[..ctx.pos()]
             .chars()
             .rev()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,20 @@
 extern crate libc;
 extern crate rustyline;
+extern crate rustyline_derive;
+
+
+use std::borrow::Cow::{self, Borrowed, Owned};
 
 use std::env;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
 use std::fs::File;
+
 use rustyline::Editor;
+use rustyline::hint::HistoryHinter;
+use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline_derive::{Helper, Hinter, Validator, Completer};
 
 mod colors;
 mod tokens;
@@ -14,13 +22,39 @@ mod tokens;
 use tokens::tokenize_commands;
 use tokens::Tokens;
 
+#[derive(Helper, Hinter, Validator, Completer)]
+struct MyHelper {
+    highlighter: MatchingBracketHighlighter,
+    #[rustyline(Hinter)]
+    hinter: HistoryHinter,
+}
+impl Highlighter for MyHelper {
+    
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
+    }
+
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
+        self.highlighter.highlight(line, pos)
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        self.highlighter.highlight_char(line, pos)
+    }
+}
+
 fn main() {
     unsafe {
         libc::signal(libc::SIGINT, libc::SIG_IGN);
         libc::signal(libc::SIGQUIT, libc::SIG_IGN);
     }
+    let h = MyHelper {
+        highlighter: MatchingBracketHighlighter::new(),
+        hinter: HistoryHinter {},
+    };
     let mut last_exit_status = true;
-    let mut rl = Editor::<()>::new().unwrap();
+    let mut rl = Editor::<MyHelper>::new().unwrap();
+    rl.set_helper(Some(h));
     let home = env::var("HOME").unwrap();
     if rl.load_history(&format!("{}/.rush_history", home)).is_err() {
         println!("No previous history.");
@@ -52,7 +86,7 @@ fn main() {
     }
 }
 
-fn read_command(rl: &mut Editor<()>, prompt_string: String) -> String {
+fn read_command(rl: &mut Editor<MyHelper>, prompt_string: String) -> String {
     let mut command_string = rl.readline(&prompt_string).unwrap();
 
     // this allows for multiline commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 extern crate rustyline;
 extern crate rustyline_derive;
+extern crate colored;
 
 use std::env;
 use std::os::unix::process::CommandExt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate libc;
 extern crate rustyline;
 extern crate rustyline_derive;
-extern crate colored;
 
 use std::env;
 use std::os::unix::process::CommandExt;
@@ -9,7 +8,7 @@ use std::path::Path;
 use std::process::Command;
 use std::fs::File;
 
-use rustyline::{Editor, KeyEvent, EventHandler};
+use rustyline::{Editor};
 
 mod colors;
 mod tokens;
@@ -17,7 +16,7 @@ mod helper;
 
 use tokens::tokenize_commands;
 use tokens::Tokens;
-use helper::{MyHelper, TabEventHandler};
+use helper::{MyHelper};
 
 
 fn main() {
@@ -29,10 +28,6 @@ fn main() {
     let mut last_exit_status = true;
     let mut rl = Editor::<MyHelper>::new().unwrap();
     rl.set_helper(Some(h));
-    rl.bind_sequence(
-        KeyEvent::from('\t'),
-        EventHandler::Conditional(Box::new(TabEventHandler)),
-    );
     let home = env::var("HOME").unwrap();
     if rl.load_history(&format!("{}/.rush_history", home)).is_err() {
         println!("No previous history.");


### PR DESCRIPTION
Previously the hint provided was just the first search result that matched the user input, and the user could not cycle through other history that matched the user input.
I've added the completer trait to fix this.
The complete function of completer now filters history candidates that match the current user input, and sends them so that they can be cycled through by pressing tab.

_At the moment, duplicate matches aren't handled, it needs to be handled when filtering history candidates._
